### PR TITLE
Fix Gingerbread Man icon on `not enough info` page

### DIFF
--- a/pages/notEnoughInfo.tsx
+++ b/pages/notEnoughInfo.tsx
@@ -6,7 +6,7 @@ import {BASE_COLOR, BG_2022} from '../src/palette';
 
 getFont();
 
-const gingerman = '/icons/gingerman.svg';
+const gingerman = '/icons/Gingerman.svg';
 
 const notEnoughInfos: React.FC = () => {
 	return (


### PR DESCRIPTION
Seeing a broken image for the Gingerbread Man on the https://2022.githubunwrapped.com/notEnoughInfo screen:

<img width="1060" alt="Screen Shot 2022-12-08 at 3 10 21 PM" src="https://user-images.githubusercontent.com/121322/206586389-2f0fc756-1e09-4341-9d78-4a876109fb73.png">
