### PR TITLE
Tweak social share text?

### DIFF
--- a/pages/[user].tsx
+++ b/pages/[user].tsx
@@ -357,7 +357,7 @@ export default function User(props: {user: CompactStats | null}) {
 									textAlign: 'center',
 								}}
 							>
-								Download your video and tweet it using{' '}
+								Download your video and share it on social media using{' '}
 								<span
 									style={{
 										color: 'black',


### PR DESCRIPTION
I'm certain that the vast majority of folks will be sharing this on Twitter, but I suspect a few folks will also share it on e.g. Instagram, LinkedIn, etc. Thoughts on making the text more generic?