### PR TITLE
Update copy for "no-contribution" error message

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -44,7 +44,7 @@ const getErrorMessage = (
 		return {
 			title: 'Not enough contributions',
 			subtitle: [
-				'Unfortunately, there are not enough contributions to make an interesting video.',
+				'Unfortunately, there are not enough contributions to make an interesting video. Make sure your GitHub profile is public.',
 				cta,
 			].join(' '),
 		};

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -42,9 +42,9 @@ const getErrorMessage = (
 			? 'Come back at the end of 2023 to get your video!'
 			: "It's not too late, get coding and then come back!";
 		return {
-			title: 'Not enough contributions',
+			title: 'Not enough public contributions',
 			subtitle: [
-				'Unfortunately, there are not enough contributions to make an interesting video. Make sure your GitHub profile is public.',
+				'Unfortunately, there are not enough public contributions to make an interesting video. Make sure your GitHub profile is public.',
 				cta,
 			].join(' '),
 		};


### PR DESCRIPTION
The error message for the no contribution need to include that profiles need to be public in order for a video to be created.

The copy has been updated to be the following for the `no-contribution` error message:

```Unfortunately, there are not enough public contributions to make an interesting video. Make sure your GitHub profile is public.```

PR based on this twitter comment: https://twitter.com/story645/status/1605604617210908691?s=20&t=_AAghYXc43ApyJgCVyDdWw 